### PR TITLE
Document Viewing

### DIFF
--- a/api/account.php
+++ b/api/account.php
@@ -74,11 +74,14 @@
 	</head>
 
 	<body class="flex flex-col justify-start h-full md:flex-row">
+
+		<!-- Tab Navigation -->
 		<search class="flex flex-row w-full md:w-1/5 md:flex-col">
 			<div class="p-16 w-1/8 md:w-full">
 				<a href="/index"><img src="/templogo.svg" alt="Temporary Blue Docs Logo"></a>
 			</div>
 
+			<!-- Navigation Buttons -->
 			<div class="flex flex-row gap-5 mx-14 my-4 md:flex-col">
 				<label for="accountSelect" class="select-none relative cursor-pointer text-lg rounded-lg p-3 border border-4 border-transparent has-checked:bg-sky-200 has-checked:border-sky-400">
 					<input autocomplete="off" checked type="radio" onclick="contentSelect('account')" id="accountSelect" name="accountContent" class="cursor-pointer absolute appearance-none inset-0" required/>
@@ -148,6 +151,7 @@
 
 				<hr class="border-gray-500 border-2">
 
+				<!-- User Attributes -->
 				<div class="flex flex-row">
 					<div class="w-1/2 flex flex-col">
 						<h1 class="text-xl font-bold">About</h1>
@@ -165,6 +169,7 @@
 						?>
 					</div>
 
+					<!-- User Preferences -->
 					<div class="w-1/2 flex flex-col">
 						<h1 class="text-xl font-bold">My Setup</h1>
 						<h2 class="text-md font-bold">Default Language:</h2>
@@ -207,6 +212,7 @@
 
 					<hr class="border-gray-500 border-2">
 
+					<!-- Account Management Forms -->
 					<h1 class="text-xl font-bold">Account Management</h1>
 
 					<div class="flex p-4">
@@ -254,6 +260,7 @@
 			<div id="documents" hidden>
 				<h1 class="text-xl mb-3">Documents</h1>
 
+				<!-- Recently Viewed Documents -->
 				<div>
 					<h2 class="text-md font-bold">Recently Viewed</h2>
 
@@ -270,6 +277,7 @@
 					</div>
 				</div>
 
+				<!-- Bookmarked Documents -->
 				<div>
 					<h2 class="text-md font-bold">Bookmarked</h2>
 
@@ -286,6 +294,7 @@
 					</div>
 				</div>
 
+				<!-- Uploaded DOcuments -->
 				<div>
 					<h2 class="text-md font-bold">My Documentation</h2>
 
@@ -425,6 +434,7 @@
 			event.stopPropagation();
 		});
 
+		/* Enables account delete button if email is typed. */
 		document.getElementById('deleteEmail').addEventListener('input', (event) => {
 			if (document.getElementById('deleteEmail').value == '<?php echo $userSession['user']['email'] ?>') {
 				document.getElementById('deleteAccountSubmit').disabled = false;
@@ -455,6 +465,7 @@
 			'defaultengine': '<?php echo $userSettingsResults[0]['default_engine'] ?>'
 		}
 
+		/* Displays tab if selected. */
 		function contentSelect(pageSelected) {
 			for (const pageName of contentList) {
 				if (pageSelected == pageName) {
@@ -483,6 +494,7 @@
 			});
 		}
 
+		/* Enables account changes submit if a value is changed from the original value when loading the page. */
 		function toggleSubmit() {
 			if (document.getElementById('firstname').value != userAttributes['firstname'] ||
 				document.getElementById('lastinitial').value != userAttributes['lastinitial'] ||

--- a/api/account.php
+++ b/api/account.php
@@ -50,7 +50,7 @@
 		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 		/* Set SQL Query */
-		$stmt = $pdo->query('SELECT name, description, author, date_created, user_uploaded FROM markdown_files');
+		$stmt = $pdo->query('SELECT id, name, description, author, date_created, user_uploaded FROM markdown_files');
 		$results = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 		/* Set SQL Query */
@@ -306,7 +306,7 @@
 								foreach ($results as $document) {
 									if ($userSession['user']['id'] == $document['user_uploaded']) {
 										echo
-										'<a href="#" class="w-sm flex flex-col gap-1 bg-sky-400 p-6 m-2 rounded-lg h-39">
+										'<a href="/doc?id=' . $document['id'] . '" class="w-sm flex flex-col gap-1 bg-sky-400 p-6 m-2 rounded-lg h-39">
 											<h3 class="text-lg font-bold">' . $document['name'] . '</h3>
 											<div>
 												<p class="text-xs truncate">Author: <span class="authorName">' . $document['author'] . '</span></p>

--- a/api/document.php
+++ b/api/document.php
@@ -60,7 +60,7 @@
         <meta charset="UTF-8">
         <title><?php echo $docResults[0]['name'] ?></title>
 
-        <link href="/public/output.css" rel="stylesheet" type="text/css">
+        <link href="/output.css" rel="stylesheet" type="text/css">
         <script src="https://cdn.jsdelivr.net/npm/@tailwindplus/elements@1" type="module"></script>
     </head>
 

--- a/api/document.php
+++ b/api/document.php
@@ -126,6 +126,7 @@
     <script>
         var slideToggle = true;
 
+        /* Slides document when comment drawer is opened. */
         function docSlide() {
             if (slideToggle) {
                 document.getElementById('docContainer').animate([
@@ -149,6 +150,7 @@
             slideToggle = !slideToggle;
         }
 
+        /* Slides document back if comment drawer begins to close. */
         function determineSlide(event) {
             if (!document.getElementById('clickBox').contains(event.target)) {
                 docSlide();

--- a/api/document.php
+++ b/api/document.php
@@ -10,6 +10,7 @@
 	    $password = "endpoint=" . $_ENV['BLUE_DOCS_NEON_PROJECT_ID'] . ";" . $_ENV['BLUE_DOCS_PGPASSWORD'];
 	    //$options = [ endpoint => $_ENV['NEON_PROJECT_ID'] ];
 
+        /* Fetch file for display. */
         try {
             /* Set Connection Details */
             $dbInfo = sprintf("pgsql:host=%s;port=%d;dbname=%s;sslmode=require", $host, $port, $dbname);
@@ -17,10 +18,31 @@
             $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
             /* Set SQL Query */
-            $currentURI = explode('/', parse_url($_SERVER['REQUEST_URI'])['path']);
-            $stmt = $pdo->query('SELECT * FROM markdown_files WHERE id = ' . end($currentURI) . ' LIMIT 1');
-            $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $stmt = $pdo->query('SELECT * FROM markdown_files WHERE id = ' . $_GET['id'] . ' LIMIT 1');
+            $docResults = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
+        } catch (PDOException $e) {
+            die("Database connection failed: " . $e->getMessage());
+        }
+
+        /* Fetch comments related to file. */
+        try {
+            /* Set SQL Query */
+            $stmt = $pdo->query('SELECT * FROM comments WHERE doc_id = ' . $_GET['id']);
+            $commentResults = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        } catch (PDOException $e) {
+            die("Database connection failed: " . $e->getMessage());
+        }
+
+        /* Fetch user names and images and append to comment array. */
+        try {
+            foreach ($commentResults as &$comment) {
+                $stmt = $pdo->query('SELECT name, image FROM neon_auth.user WHERE id = \'' . $comment['user_id'] . '\' LIMIT 1');
+                $userResults = $stmt->fetchAll(PDO::FETCH_ASSOC);
+                $comment['name'] = $userResults[0]['name'];
+                $comment['image'] = $userResults[0]['image'];
+            }
         } catch (PDOException $e) {
             die("Database connection failed: " . $e->getMessage());
         }
@@ -36,20 +58,20 @@
 <html>
     <head>
         <meta charset="UTF-8">
-        <title><?php echo $results[0]['name'] ?></title>
+        <title><?php echo $docResults[0]['name'] ?></title>
 
-        <link href="/output.css" rel="stylesheet" type="text/css">
+        <link href="/public/output.css" rel="stylesheet" type="text/css">
         <script src="https://cdn.jsdelivr.net/npm/@tailwindplus/elements@1" type="module"></script>
     </head>
 
     <body>
-        <main class="flex justify-center">
+        <main class="flex justify-center p-4">
             <!-- Document Page -->
 	        <div id="docContainer" shadowrootmode="open" class="markdown-body flex flex-col w-7/10 p-4 rounded-xl">
                 <link href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.8.1/github-markdown.min.css" rel="stylesheet" type="text/css">
 
                 <?php
-                    echo $results[0]['name'] . '.md'; 
+                    echo $docResults[0]['name'] . '.md'; 
                 ?>
 
                 <?php
@@ -57,7 +79,7 @@
 
                     $parsedown = new Parsedown();
                     $parsedown -> setSafeMode(false); //Turning this on escapes < and > and displays "<br>"
-                    $htmlOutput = $parsedown->text(stream_get_contents($results[0]['contents']));
+                    $htmlOutput = $parsedown->text(stream_get_contents($docResults[0]['contents']));
 
                     echo $htmlOutput;
                 ?>
@@ -67,8 +89,28 @@
 			<el-dialog>
 				<dialog id="commentDrawer" onClick="determineSlide(event)" class="fixed inset-0 size-auto max-h-none max-w-none bg-transparent backdrop:bg-transparent">
 					<div id="clickBox" tabindex="0" class="absolute inset-y-0 right-0 w-3/10 focus:outline-none">
-						<el-dialog-panel class="group/dialog-panel mr-auto block size-full bg-red-500 transform transition duration-500 ease-in-out data-closed:translate-x-full sm:duration-700">
-                            
+						<el-dialog-panel class="group/dialog-panel mr-auto block size-full p-4 pl-3 transform transition duration-500 ease-in-out data-closed:translate-x-full sm:duration-700">
+                            <div class="size-full bg-gray-300 rounded-xl p-3 overflow-auto flex flex-col gap-4">
+                                <h2>Comments</h2>
+
+                                <?php
+                                    foreach ($commentResults as $comment) {
+                                        $date = new DateTime();
+					                    $date->setTimestamp(strtotime($comment['date_uploaded']));
+					                    $date->setTimezone(new DateTimeZone('America/Detroit'));
+					                    $date = $date->format(DateTime::W3C);
+
+                                        echo
+                                        '<div class="bg-gray-400 rounded-lg flex flex-col gap-2 p-2">
+                                            <div>
+                                                <h3>' . $comment['image'] . ' ' . $comment['name'] . '</h3>
+                                                <h3>' . substr($date, 0, strpos($date, 'T')) . '</h3>
+                                            </div>
+                                            <p>' . $comment['contents'] . '</p>
+                                        </div>';
+                                    }
+                                ?>
+                            </div>
 						</el-dialog-panel>
 					</div>
 				</dialog>

--- a/api/document.php
+++ b/api/document.php
@@ -1,0 +1,116 @@
+<?php
+	if ($_SERVER['REQUEST_METHOD'] == 'GET') {
+        /* Pull document information via SQL connection. */
+
+	    /* Set SQL Settings */
+	    $host = $_ENV['BLUE_DOCS_PGHOST'];
+	    $port = $_ENV['BLUE_DOCS_PGPORT'] ?? 5432;
+	    $dbname = $_ENV['BLUE_DOCS_PGDATABASE'];
+	    $user = $_ENV['BLUE_DOCS_PGUSER'];
+	    $password = "endpoint=" . $_ENV['BLUE_DOCS_NEON_PROJECT_ID'] . ";" . $_ENV['BLUE_DOCS_PGPASSWORD'];
+	    //$options = [ endpoint => $_ENV['NEON_PROJECT_ID'] ];
+
+        try {
+            /* Set Connection Details */
+            $dbInfo = sprintf("pgsql:host=%s;port=%d;dbname=%s;sslmode=require", $host, $port, $dbname);
+            $pdo = new PDO($dbInfo, $user, $password/*, $options*/);
+            $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+            /* Set SQL Query */
+            $currentURI = explode('/', parse_url($_SERVER['REQUEST_URI'])['path']);
+            $stmt = $pdo->query('SELECT * FROM markdown_files WHERE id = ' . end($currentURI) . ' LIMIT 1');
+            $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        } catch (PDOException $e) {
+            die("Database connection failed: " . $e->getMessage());
+        }
+
+	/* Return if not a GET Request */
+	} else {
+		http_response_code(405);
+		exit('Method not allowed.');
+	}
+?>
+
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <title><?php echo $results[0]['name'] ?></title>
+
+        <link href="/public/output.css" rel="stylesheet" type="text/css">
+        <script src="https://cdn.jsdelivr.net/npm/@tailwindplus/elements@1" type="module"></script>
+    </head>
+
+    <body>
+        <main class="flex justify-center">
+            <!-- Document Page -->
+	        <div id="docContainer" shadowrootmode="open" class="markdown-body flex flex-col w-7/10 p-4 rounded-xl">
+                <link href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.8.1/github-markdown.min.css" rel="stylesheet" type="text/css">
+
+                <?php
+                    echo $results[0]['name'] . '.md'; 
+                ?>
+
+                <?php
+                    require '../lib/Parsedown.php';
+
+                    $parsedown = new Parsedown();
+                    $parsedown -> setSafeMode(false); //Turning this on escapes < and > and displays "<br>"
+                    $htmlOutput = $parsedown->text(stream_get_contents($results[0]['contents']));
+
+                    echo $htmlOutput;
+                ?>
+            </div>
+
+            <!-- Comment Drawer -->
+			<el-dialog>
+				<dialog id="commentDrawer" onClick="determineSlide(event)" class="fixed inset-0 size-auto max-h-none max-w-none bg-transparent backdrop:bg-transparent">
+					<div id="clickBox" tabindex="0" class="absolute inset-y-0 right-0 w-3/10 focus:outline-none">
+						<el-dialog-panel class="group/dialog-panel mr-auto block size-full bg-red-500 transform transition duration-500 ease-in-out data-closed:translate-x-full sm:duration-700">
+                            
+						</el-dialog-panel>
+					</div>
+				</dialog>
+			</el-dialog>
+        </main>
+
+        <button command="show-modal" commandfor="commentDrawer" onclick="docSlide()" class="fixed cursor-pointer top-5 right-5">
+			<span class="sr-only">Open Filter Menu</span>
+			<img src="https://static.thenounproject.com/png/filter-icon-8291957-512.png" alt="Filter Icon" class="size-8">
+		</button>
+    </body>
+
+    <script>
+        var slideToggle = true;
+
+        function docSlide() {
+            if (slideToggle) {
+                document.getElementById('docContainer').animate([
+                    { transform: 'translateX(0)' },
+                    { transform: 'translateX(-21.429%)' }
+                ], {
+                    duration: 500,
+                    easing: 'ease-in-out',
+                    fill: 'forwards'
+                });
+            } else {
+                document.getElementById('docContainer').animate([
+                    { transform: 'translateX(-21.429%)' },
+                    { transform: 'translateX(0)' }
+                ], {
+                    duration: 500,
+                    easing: 'ease-in-out',
+                    fill: 'forwards'
+                });
+            }
+            slideToggle = !slideToggle;
+        }
+
+        function determineSlide(event) {
+            if (!document.getElementById('clickBox').contains(event.target)) {
+                docSlide();
+            }
+        }
+    </script>
+</html>

--- a/api/document.php
+++ b/api/document.php
@@ -38,7 +38,7 @@
         <meta charset="UTF-8">
         <title><?php echo $results[0]['name'] ?></title>
 
-        <link href="/public/output.css" rel="stylesheet" type="text/css">
+        <link href="/output.css" rel="stylesheet" type="text/css">
         <script src="https://cdn.jsdelivr.net/npm/@tailwindplus/elements@1" type="module"></script>
     </head>
 

--- a/api/index.php
+++ b/api/index.php
@@ -279,7 +279,7 @@
 					$date = $date->format(DateTime::W3C);
 
 					echo
-					'<a href="#" hidden class="flex flex-col gap-1 bg-sky-400 p-6 m-6 rounded-lg h-39">
+					'<a href="/doc/' . $document['id'] . '" hidden class="flex flex-col gap-1 bg-sky-400 p-6 m-6 rounded-lg h-39">
 						<h3 class="text-lg font-bold">' . $document['name'] . '</h3>
 						<div>
 							<p class="text-xs truncate">Author: <span class="authorName">' . $document['author'] . '</span></p>

--- a/api/index.php
+++ b/api/index.php
@@ -48,7 +48,7 @@
 		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 		/* Set SQL Query */
-		$stmt = $pdo->query('SELECT name, description, author, date_created FROM markdown_files');
+		$stmt = $pdo->query('SELECT id, name, description, author, date_created FROM markdown_files');
 		$results = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 	} catch (PDOException $e) {
@@ -279,7 +279,7 @@
 					$date = $date->format(DateTime::W3C);
 
 					echo
-					'<a href="/doc/' . $document['id'] . '" hidden class="flex flex-col gap-1 bg-sky-400 p-6 m-6 rounded-lg h-39">
+					'<a href="/doc?id=' . $document['id'] . '" hidden class="flex flex-col gap-1 bg-sky-400 p-6 m-6 rounded-lg h-39">
 						<h3 class="text-lg font-bold">' . $document['name'] . '</h3>
 						<div>
 							<p class="text-xs truncate">Author: <span class="authorName">' . $document['author'] . '</span></p>

--- a/api/login.php
+++ b/api/login.php
@@ -108,6 +108,7 @@
 	<script>
 		const errorSpan = document.getElementById('errorSpan');
 
+		/* Submits login request through Neon API. */
 		function submitLogin() {
 			const formData = new FormData(document.getElementById('loginForm'));
 			if (formData.get('email') && formData.get('password')) {
@@ -156,6 +157,7 @@
 			}
 		});
 
+		/* Resets email input as valid. */
 		function resetEmail() {
 			document.getElementById('email').setCustomValidity('');
 			errorSpan.textContent = '';

--- a/api/signup.php
+++ b/api/signup.php
@@ -102,6 +102,7 @@
 	<script>
 		const errorSpan = document.getElementById('errorSpan');
 
+		/* Submits user signup request through Neon API. */
 		function submitSignup() {
 			const formData = new FormData(document.getElementById('signUpForm'));
 			if (formData.get('email') && formData.get('password') && formData.get('confirmpassword') && formData.get('firstname') && formData.get('lastinitial')) {
@@ -161,6 +162,7 @@
 			}
 		});
 
+		/* Resets form inputs as valid. */
 		function resetForm() {
 			document.getElementById('email').setCustomValidity('');
 			document.getElementById('password').setCustomValidity('');

--- a/api/verification.php
+++ b/api/verification.php
@@ -124,6 +124,8 @@
 			
 			if (otpCode.length == 6) {
 				errorSpan.innerHTML = '<img src="/loading.gif" alt="Loading GIF" class="size-6">';
+
+				/* Sends verification request through Neon API. */
 				fetch('/verification', {
 					method: 'POST',
 					headers: {
@@ -178,11 +180,6 @@
 				errorSpan.textContent = error.message;
 			});
 		}
-
-		function resetEmail() {
-			document.getElementById('email').setCustomValidity('');
-			errorSpan.textContent = '';
-		}
 	</script>
 
 	<script>
@@ -194,6 +191,7 @@
 				e.preventDefault();
 			}
 
+			/* Deletes current digit if exists, otherwise try to delete previous digits and move cursor left. */
 			if (e.key === 'Delete' || e.key === 'Backspace') {
 				const index = verificationDigits.indexOf(e.target);
 				if (verificationDigits[index].value != '') {
@@ -205,6 +203,7 @@
 				}
 			}
 
+			/* Tries to submit OTP if submission is enabled. */
 			if (!document.getElementById('otpSubmit').disabled && (e.key === 'Enter' || e.keyCode === 13)) {
 				document.getElementById('otpSubmit').click();
 			}
@@ -214,6 +213,8 @@
 		const handleInput = (e) => {
 			const { target } = e;
 			const index = verificationDigits.indexOf(target)
+
+			/* Shifts cursor right when inputting digit, or enable submit if digits are full. */
 			if (target.value) {
 				if (index < verificationDigits.length - 1) {
 					verificationDigits[index + 1].focus();
@@ -262,6 +263,7 @@
 			}
 		}
 
+		/* Attach listeners to all inputs. */
 		verificationDigits.forEach((input) => {
             input.addEventListener('input', handleInput);
             input.addEventListener('keydown', handleKeyDown);

--- a/api/verification.php
+++ b/api/verification.php
@@ -124,6 +124,8 @@
 			
 			if (otpCode.length == 6) {
 				errorSpan.innerHTML = '<img src="/loading.gif" alt="Loading GIF" class="size-6">';
+
+				/* Sends verification request through Neon API. */
 				fetch('/verification', {
 					method: 'POST',
 					headers: {
@@ -178,19 +180,6 @@
 				errorSpan.textContent = error.message;
 			});
 		}
-
-		/* Allow usage of ENTER key to submit OTP request. */
-		document.addEventListener('keydown', function(event) {
-			if (!document.getElementById('otpSubmit').disabled && (event.key === 'Enter' || event.keyCode === 13)) {
-				event.preventDefault();
-				document.getElementById('otpSubmit').click();
-			}
-		});
-
-		function resetEmail() {
-			document.getElementById('email').setCustomValidity('');
-			errorSpan.textContent = '';
-		}
 	</script>
 
 	<script>
@@ -202,6 +191,7 @@
 				e.preventDefault();
 			}
 
+			/* Deletes current digit if exists, otherwise try to delete previous digits and move cursor left. */
 			if (e.key === 'Delete' || e.key === 'Backspace') {
 				const index = verificationDigits.indexOf(e.target);
 				if (verificationDigits[index].value != '') {
@@ -212,12 +202,19 @@
 					verificationDigits[index - 1].focus();
 				}
 			}
+
+			/* Tries to submit OTP if submission is enabled. */
+			if (!document.getElementById('otpSubmit').disabled && (e.key === 'Enter' || e.keyCode === 13)) {
+				document.getElementById('otpSubmit').click();
+			}
 		}
 
 		/* Handle Input Update */
 		const handleInput = (e) => {
 			const { target } = e;
 			const index = verificationDigits.indexOf(target)
+
+			/* Shifts cursor right when inputting digit, or enable submit if digits are full. */
 			if (target.value) {
 				if (index < verificationDigits.length - 1) {
 					verificationDigits[index + 1].focus();
@@ -266,6 +263,7 @@
 			}
 		}
 
+		/* Attach listeners to all inputs. */
 		verificationDigits.forEach((input) => {
             input.addEventListener('input', handleInput);
             input.addEventListener('keydown', handleKeyDown);

--- a/api/verification.php
+++ b/api/verification.php
@@ -141,7 +141,7 @@
 				.then(data => {
 					if (data !== undefined) {
 						if ('user' in data) {
-							window.location.href='/index';
+							window.location.href='/login';
 						} else {
 							errorSpan.textContent = data.message;
 						}

--- a/lib/Parsedown.php
+++ b/lib/Parsedown.php
@@ -1,0 +1,1995 @@
+<?php
+
+#
+#
+# Parsedown
+# http://parsedown.org
+#
+# (c) Emanuil Rusev
+# http://erusev.com
+#
+# For the full license information, view the LICENSE file that was distributed
+# with this source code.
+#
+#
+
+class Parsedown
+{
+    # ~
+
+    const version = '1.8.0';
+
+    # ~
+
+    function text($text)
+    {
+        $Elements = $this->textElements($text);
+
+        # convert to markup
+        $markup = $this->elements($Elements);
+
+        # trim line breaks
+        $markup = trim($markup, "\n");
+
+        return $markup;
+    }
+
+    protected function textElements($text)
+    {
+        # make sure no definitions are set
+        $this->DefinitionData = array();
+
+        # standardize line breaks
+        $text = str_replace(array("\r\n", "\r"), "\n", $text);
+
+        # remove surrounding line breaks
+        $text = trim($text, "\n");
+
+        # split text into lines
+        $lines = explode("\n", $text);
+
+        # iterate through lines to identify blocks
+        return $this->linesElements($lines);
+    }
+
+    #
+    # Setters
+    #
+
+    function setBreaksEnabled($breaksEnabled)
+    {
+        $this->breaksEnabled = $breaksEnabled;
+
+        return $this;
+    }
+
+    protected $breaksEnabled;
+
+    function setMarkupEscaped($markupEscaped)
+    {
+        $this->markupEscaped = $markupEscaped;
+
+        return $this;
+    }
+
+    protected $markupEscaped;
+
+    function setUrlsLinked($urlsLinked)
+    {
+        $this->urlsLinked = $urlsLinked;
+
+        return $this;
+    }
+
+    protected $urlsLinked = true;
+
+    function setSafeMode($safeMode)
+    {
+        $this->safeMode = (bool) $safeMode;
+
+        return $this;
+    }
+
+    protected $safeMode;
+
+    function setStrictMode($strictMode)
+    {
+        $this->strictMode = (bool) $strictMode;
+
+        return $this;
+    }
+
+    protected $strictMode;
+
+    protected $safeLinksWhitelist = array(
+        'http://',
+        'https://',
+        'ftp://',
+        'ftps://',
+        'mailto:',
+        'tel:',
+        'data:image/png;base64,',
+        'data:image/gif;base64,',
+        'data:image/jpeg;base64,',
+        'irc:',
+        'ircs:',
+        'git:',
+        'ssh:',
+        'news:',
+        'steam:',
+    );
+
+    #
+    # Lines
+    #
+
+    protected $BlockTypes = array(
+        '#' => array('Header'),
+        '*' => array('Rule', 'List'),
+        '+' => array('List'),
+        '-' => array('SetextHeader', 'Table', 'Rule', 'List'),
+        '0' => array('List'),
+        '1' => array('List'),
+        '2' => array('List'),
+        '3' => array('List'),
+        '4' => array('List'),
+        '5' => array('List'),
+        '6' => array('List'),
+        '7' => array('List'),
+        '8' => array('List'),
+        '9' => array('List'),
+        ':' => array('Table'),
+        '<' => array('Comment', 'Markup'),
+        '=' => array('SetextHeader'),
+        '>' => array('Quote'),
+        '[' => array('Reference'),
+        '_' => array('Rule'),
+        '`' => array('FencedCode'),
+        '|' => array('Table'),
+        '~' => array('FencedCode'),
+    );
+
+    # ~
+
+    protected $unmarkedBlockTypes = array(
+        'Code',
+    );
+
+    #
+    # Blocks
+    #
+
+    protected function lines(array $lines)
+    {
+        return $this->elements($this->linesElements($lines));
+    }
+
+    protected function linesElements(array $lines)
+    {
+        $Elements = array();
+        $CurrentBlock = null;
+
+        foreach ($lines as $line)
+        {
+            if (chop($line) === '')
+            {
+                if (isset($CurrentBlock))
+                {
+                    $CurrentBlock['interrupted'] = (isset($CurrentBlock['interrupted'])
+                        ? $CurrentBlock['interrupted'] + 1 : 1
+                    );
+                }
+
+                continue;
+            }
+
+            while (($beforeTab = strstr($line, "\t", true)) !== false)
+            {
+                $shortage = 4 - mb_strlen($beforeTab, 'utf-8') % 4;
+
+                $line = $beforeTab
+                    . str_repeat(' ', $shortage)
+                    . substr($line, strlen($beforeTab) + 1)
+                ;
+            }
+
+            $indent = strspn($line, ' ');
+
+            $text = $indent > 0 ? substr($line, $indent) : $line;
+
+            # ~
+
+            $Line = array('body' => $line, 'indent' => $indent, 'text' => $text);
+
+            # ~
+
+            if (isset($CurrentBlock['continuable']))
+            {
+                $methodName = 'block' . $CurrentBlock['type'] . 'Continue';
+                $Block = $this->$methodName($Line, $CurrentBlock);
+
+                if (isset($Block))
+                {
+                    $CurrentBlock = $Block;
+
+                    continue;
+                }
+                else
+                {
+                    if ($this->isBlockCompletable($CurrentBlock['type']))
+                    {
+                        $methodName = 'block' . $CurrentBlock['type'] . 'Complete';
+                        $CurrentBlock = $this->$methodName($CurrentBlock);
+                    }
+                }
+            }
+
+            # ~
+
+            $marker = $text[0];
+
+            # ~
+
+            $blockTypes = $this->unmarkedBlockTypes;
+
+            if (isset($this->BlockTypes[$marker]))
+            {
+                foreach ($this->BlockTypes[$marker] as $blockType)
+                {
+                    $blockTypes []= $blockType;
+                }
+            }
+
+            #
+            # ~
+
+            foreach ($blockTypes as $blockType)
+            {
+                $Block = $this->{"block$blockType"}($Line, $CurrentBlock);
+
+                if (isset($Block))
+                {
+                    $Block['type'] = $blockType;
+
+                    if ( ! isset($Block['identified']))
+                    {
+                        if (isset($CurrentBlock))
+                        {
+                            $Elements[] = $this->extractElement($CurrentBlock);
+                        }
+
+                        $Block['identified'] = true;
+                    }
+
+                    if ($this->isBlockContinuable($blockType))
+                    {
+                        $Block['continuable'] = true;
+                    }
+
+                    $CurrentBlock = $Block;
+
+                    continue 2;
+                }
+            }
+
+            # ~
+
+            if (isset($CurrentBlock) and $CurrentBlock['type'] === 'Paragraph')
+            {
+                $Block = $this->paragraphContinue($Line, $CurrentBlock);
+            }
+
+            if (isset($Block))
+            {
+                $CurrentBlock = $Block;
+            }
+            else
+            {
+                if (isset($CurrentBlock))
+                {
+                    $Elements[] = $this->extractElement($CurrentBlock);
+                }
+
+                $CurrentBlock = $this->paragraph($Line);
+
+                $CurrentBlock['identified'] = true;
+            }
+        }
+
+        # ~
+
+        if (isset($CurrentBlock['continuable']) and $this->isBlockCompletable($CurrentBlock['type']))
+        {
+            $methodName = 'block' . $CurrentBlock['type'] . 'Complete';
+            $CurrentBlock = $this->$methodName($CurrentBlock);
+        }
+
+        # ~
+
+        if (isset($CurrentBlock))
+        {
+            $Elements[] = $this->extractElement($CurrentBlock);
+        }
+
+        # ~
+
+        return $Elements;
+    }
+
+    protected function extractElement(array $Component)
+    {
+        if ( ! isset($Component['element']))
+        {
+            if (isset($Component['markup']))
+            {
+                $Component['element'] = array('rawHtml' => $Component['markup']);
+            }
+            elseif (isset($Component['hidden']))
+            {
+                $Component['element'] = array();
+            }
+        }
+
+        return $Component['element'];
+    }
+
+    protected function isBlockContinuable($Type)
+    {
+        return method_exists($this, 'block' . $Type . 'Continue');
+    }
+
+    protected function isBlockCompletable($Type)
+    {
+        return method_exists($this, 'block' . $Type . 'Complete');
+    }
+
+    #
+    # Code
+
+    protected function blockCode($Line, $Block = null)
+    {
+        if (isset($Block) and $Block['type'] === 'Paragraph' and ! isset($Block['interrupted']))
+        {
+            return;
+        }
+
+        if ($Line['indent'] >= 4)
+        {
+            $text = substr($Line['body'], 4);
+
+            $Block = array(
+                'element' => array(
+                    'name' => 'pre',
+                    'element' => array(
+                        'name' => 'code',
+                        'text' => $text,
+                    ),
+                ),
+            );
+
+            return $Block;
+        }
+    }
+
+    protected function blockCodeContinue($Line, $Block)
+    {
+        if ($Line['indent'] >= 4)
+        {
+            if (isset($Block['interrupted']))
+            {
+                $Block['element']['element']['text'] .= str_repeat("\n", $Block['interrupted']);
+
+                unset($Block['interrupted']);
+            }
+
+            $Block['element']['element']['text'] .= "\n";
+
+            $text = substr($Line['body'], 4);
+
+            $Block['element']['element']['text'] .= $text;
+
+            return $Block;
+        }
+    }
+
+    protected function blockCodeComplete($Block)
+    {
+        return $Block;
+    }
+
+    #
+    # Comment
+
+    protected function blockComment($Line)
+    {
+        if ($this->markupEscaped or $this->safeMode)
+        {
+            return;
+        }
+
+        if (strpos($Line['text'], '<!--') === 0)
+        {
+            $Block = array(
+                'element' => array(
+                    'rawHtml' => $Line['body'],
+                    'autobreak' => true,
+                ),
+            );
+
+            if (strpos($Line['text'], '-->') !== false)
+            {
+                $Block['closed'] = true;
+            }
+
+            return $Block;
+        }
+    }
+
+    protected function blockCommentContinue($Line, array $Block)
+    {
+        if (isset($Block['closed']))
+        {
+            return;
+        }
+
+        $Block['element']['rawHtml'] .= "\n" . $Line['body'];
+
+        if (strpos($Line['text'], '-->') !== false)
+        {
+            $Block['closed'] = true;
+        }
+
+        return $Block;
+    }
+
+    #
+    # Fenced Code
+
+    protected function blockFencedCode($Line)
+    {
+        $marker = $Line['text'][0];
+
+        $openerLength = strspn($Line['text'], $marker);
+
+        if ($openerLength < 3)
+        {
+            return;
+        }
+
+        $infostring = trim(substr($Line['text'], $openerLength), "\t ");
+
+        if (strpos($infostring, '`') !== false)
+        {
+            return;
+        }
+
+        $Element = array(
+            'name' => 'code',
+            'text' => '',
+        );
+
+        if ($infostring !== '')
+        {
+            /**
+             * https://www.w3.org/TR/2011/WD-html5-20110525/elements.html#classes
+             * Every HTML element may have a class attribute specified.
+             * The attribute, if specified, must have a value that is a set
+             * of space-separated tokens representing the various classes
+             * that the element belongs to.
+             * [...]
+             * The space characters, for the purposes of this specification,
+             * are U+0020 SPACE, U+0009 CHARACTER TABULATION (tab),
+             * U+000A LINE FEED (LF), U+000C FORM FEED (FF), and
+             * U+000D CARRIAGE RETURN (CR).
+             */
+            $language = substr($infostring, 0, strcspn($infostring, " \t\n\f\r"));
+
+            $Element['attributes'] = array('class' => "language-$language");
+        }
+
+        $Block = array(
+            'char' => $marker,
+            'openerLength' => $openerLength,
+            'element' => array(
+                'name' => 'pre',
+                'element' => $Element,
+            ),
+        );
+
+        return $Block;
+    }
+
+    protected function blockFencedCodeContinue($Line, $Block)
+    {
+        if (isset($Block['complete']))
+        {
+            return;
+        }
+
+        if (isset($Block['interrupted']))
+        {
+            $Block['element']['element']['text'] .= str_repeat("\n", $Block['interrupted']);
+
+            unset($Block['interrupted']);
+        }
+
+        if (($len = strspn($Line['text'], $Block['char'])) >= $Block['openerLength']
+            and chop(substr($Line['text'], $len), ' ') === ''
+        ) {
+            $Block['element']['element']['text'] = substr($Block['element']['element']['text'], 1);
+
+            $Block['complete'] = true;
+
+            return $Block;
+        }
+
+        $Block['element']['element']['text'] .= "\n" . $Line['body'];
+
+        return $Block;
+    }
+
+    protected function blockFencedCodeComplete($Block)
+    {
+        return $Block;
+    }
+
+    #
+    # Header
+
+    protected function blockHeader($Line)
+    {
+        $level = strspn($Line['text'], '#');
+
+        if ($level > 6)
+        {
+            return;
+        }
+
+        $text = trim($Line['text'], '#');
+
+        if ($this->strictMode and isset($text[0]) and $text[0] !== ' ')
+        {
+            return;
+        }
+
+        $text = trim($text, ' ');
+
+        $Block = array(
+            'element' => array(
+                'name' => 'h' . $level,
+                'handler' => array(
+                    'function' => 'lineElements',
+                    'argument' => $text,
+                    'destination' => 'elements',
+                )
+            ),
+        );
+
+        return $Block;
+    }
+
+    #
+    # List
+
+    protected function blockList($Line, ?array $CurrentBlock = null)
+    {
+        list($name, $pattern) = $Line['text'][0] <= '-' ? array('ul', '[*+-]') : array('ol', '[0-9]{1,9}+[.\)]');
+
+        if (preg_match('/^('.$pattern.'([ ]++|$))(.*+)/', $Line['text'], $matches))
+        {
+            $contentIndent = strlen($matches[2]);
+
+            if ($contentIndent >= 5)
+            {
+                $contentIndent -= 1;
+                $matches[1] = substr($matches[1], 0, -$contentIndent);
+                $matches[3] = str_repeat(' ', $contentIndent) . $matches[3];
+            }
+            elseif ($contentIndent === 0)
+            {
+                $matches[1] .= ' ';
+            }
+
+            $markerWithoutWhitespace = strstr($matches[1], ' ', true);
+
+            $Block = array(
+                'indent' => $Line['indent'],
+                'pattern' => $pattern,
+                'data' => array(
+                    'type' => $name,
+                    'marker' => $matches[1],
+                    'markerType' => ($name === 'ul' ? $markerWithoutWhitespace : substr($markerWithoutWhitespace, -1)),
+                ),
+                'element' => array(
+                    'name' => $name,
+                    'elements' => array(),
+                ),
+            );
+            $Block['data']['markerTypeRegex'] = preg_quote($Block['data']['markerType'], '/');
+
+            if ($name === 'ol')
+            {
+                $listStart = ltrim(strstr($matches[1], $Block['data']['markerType'], true), '0') ?: '0';
+
+                if ($listStart !== '1')
+                {
+                    if (
+                        isset($CurrentBlock)
+                        and $CurrentBlock['type'] === 'Paragraph'
+                        and ! isset($CurrentBlock['interrupted'])
+                    ) {
+                        return;
+                    }
+
+                    $Block['element']['attributes'] = array('start' => $listStart);
+                }
+            }
+
+            $Block['li'] = array(
+                'name' => 'li',
+                'handler' => array(
+                    'function' => 'li',
+                    'argument' => !empty($matches[3]) ? array($matches[3]) : array(),
+                    'destination' => 'elements'
+                )
+            );
+
+            $Block['element']['elements'] []= & $Block['li'];
+
+            return $Block;
+        }
+    }
+
+    protected function blockListContinue($Line, array $Block)
+    {
+        if (isset($Block['interrupted']) and empty($Block['li']['handler']['argument']))
+        {
+            return null;
+        }
+
+        $requiredIndent = ($Block['indent'] + strlen($Block['data']['marker']));
+
+        if ($Line['indent'] < $requiredIndent
+            and (
+                (
+                    $Block['data']['type'] === 'ol'
+                    and preg_match('/^[0-9]++'.$Block['data']['markerTypeRegex'].'(?:[ ]++(.*)|$)/', $Line['text'], $matches)
+                ) or (
+                    $Block['data']['type'] === 'ul'
+                    and preg_match('/^'.$Block['data']['markerTypeRegex'].'(?:[ ]++(.*)|$)/', $Line['text'], $matches)
+                )
+            )
+        ) {
+            if (isset($Block['interrupted']))
+            {
+                $Block['li']['handler']['argument'] []= '';
+
+                $Block['loose'] = true;
+
+                unset($Block['interrupted']);
+            }
+
+            unset($Block['li']);
+
+            $text = isset($matches[1]) ? $matches[1] : '';
+
+            $Block['indent'] = $Line['indent'];
+
+            $Block['li'] = array(
+                'name' => 'li',
+                'handler' => array(
+                    'function' => 'li',
+                    'argument' => array($text),
+                    'destination' => 'elements'
+                )
+            );
+
+            $Block['element']['elements'] []= & $Block['li'];
+
+            return $Block;
+        }
+        elseif ($Line['indent'] < $requiredIndent and $this->blockList($Line))
+        {
+            return null;
+        }
+
+        if ($Line['text'][0] === '[' and $this->blockReference($Line))
+        {
+            return $Block;
+        }
+
+        if ($Line['indent'] >= $requiredIndent)
+        {
+            if (isset($Block['interrupted']))
+            {
+                $Block['li']['handler']['argument'] []= '';
+
+                $Block['loose'] = true;
+
+                unset($Block['interrupted']);
+            }
+
+            $text = substr($Line['body'], $requiredIndent);
+
+            $Block['li']['handler']['argument'] []= $text;
+
+            return $Block;
+        }
+
+        if ( ! isset($Block['interrupted']))
+        {
+            $text = preg_replace('/^[ ]{0,'.$requiredIndent.'}+/', '', $Line['body']);
+
+            $Block['li']['handler']['argument'] []= $text;
+
+            return $Block;
+        }
+    }
+
+    protected function blockListComplete(array $Block)
+    {
+        if (isset($Block['loose']))
+        {
+            foreach ($Block['element']['elements'] as &$li)
+            {
+                if (end($li['handler']['argument']) !== '')
+                {
+                    $li['handler']['argument'] []= '';
+                }
+            }
+        }
+
+        return $Block;
+    }
+
+    #
+    # Quote
+
+    protected function blockQuote($Line)
+    {
+        if (preg_match('/^>[ ]?+(.*+)/', $Line['text'], $matches))
+        {
+            $Block = array(
+                'element' => array(
+                    'name' => 'blockquote',
+                    'handler' => array(
+                        'function' => 'linesElements',
+                        'argument' => (array) $matches[1],
+                        'destination' => 'elements',
+                    )
+                ),
+            );
+
+            return $Block;
+        }
+    }
+
+    protected function blockQuoteContinue($Line, array $Block)
+    {
+        if (isset($Block['interrupted']))
+        {
+            return;
+        }
+
+        if ($Line['text'][0] === '>' and preg_match('/^>[ ]?+(.*+)/', $Line['text'], $matches))
+        {
+            $Block['element']['handler']['argument'] []= $matches[1];
+
+            return $Block;
+        }
+
+        if ( ! isset($Block['interrupted']))
+        {
+            $Block['element']['handler']['argument'] []= $Line['text'];
+
+            return $Block;
+        }
+    }
+
+    #
+    # Rule
+
+    protected function blockRule($Line)
+    {
+        $marker = $Line['text'][0];
+
+        if (substr_count($Line['text'], $marker) >= 3 and chop($Line['text'], " $marker") === '')
+        {
+            $Block = array(
+                'element' => array(
+                    'name' => 'hr',
+                ),
+            );
+
+            return $Block;
+        }
+    }
+
+    #
+    # Setext
+
+    protected function blockSetextHeader($Line, ?array $Block = null)
+    {
+        if ( ! isset($Block) or $Block['type'] !== 'Paragraph' or isset($Block['interrupted']))
+        {
+            return;
+        }
+
+        if ($Line['indent'] < 4 and chop(chop($Line['text'], ' '), $Line['text'][0]) === '')
+        {
+            $Block['element']['name'] = $Line['text'][0] === '=' ? 'h1' : 'h2';
+
+            return $Block;
+        }
+    }
+
+    #
+    # Markup
+
+    protected function blockMarkup($Line)
+    {
+        if ($this->markupEscaped or $this->safeMode)
+        {
+            return;
+        }
+
+        if (preg_match('/^<[\/]?+(\w*)(?:[ ]*+'.$this->regexHtmlAttribute.')*+[ ]*+(\/)?>/', $Line['text'], $matches))
+        {
+            $element = strtolower($matches[1]);
+
+            if (in_array($element, $this->textLevelElements))
+            {
+                return;
+            }
+
+            $Block = array(
+                'name' => $matches[1],
+                'element' => array(
+                    'rawHtml' => $Line['text'],
+                    'autobreak' => true,
+                ),
+            );
+
+            return $Block;
+        }
+    }
+
+    protected function blockMarkupContinue($Line, array $Block)
+    {
+        if (isset($Block['closed']) or isset($Block['interrupted']))
+        {
+            return;
+        }
+
+        $Block['element']['rawHtml'] .= "\n" . $Line['body'];
+
+        return $Block;
+    }
+
+    #
+    # Reference
+
+    protected function blockReference($Line)
+    {
+        if (strpos($Line['text'], ']') !== false
+            and preg_match('/^\[(.+?)\]:[ ]*+<?(\S+?)>?(?:[ ]+["\'(](.+)["\')])?[ ]*+$/', $Line['text'], $matches)
+        ) {
+            $id = strtolower($matches[1]);
+
+            $Data = array(
+                'url' => $matches[2],
+                'title' => isset($matches[3]) ? $matches[3] : null,
+            );
+
+            $this->DefinitionData['Reference'][$id] = $Data;
+
+            $Block = array(
+                'element' => array(),
+            );
+
+            return $Block;
+        }
+    }
+
+    #
+    # Table
+
+    protected function blockTable($Line, ?array $Block = null)
+    {
+        if ( ! isset($Block) or $Block['type'] !== 'Paragraph' or isset($Block['interrupted']))
+        {
+            return;
+        }
+
+        if (
+            strpos($Block['element']['handler']['argument'], '|') === false
+            and strpos($Line['text'], '|') === false
+            and strpos($Line['text'], ':') === false
+            or strpos($Block['element']['handler']['argument'], "\n") !== false
+        ) {
+            return;
+        }
+
+        if (chop($Line['text'], ' -:|') !== '')
+        {
+            return;
+        }
+
+        $alignments = array();
+
+        $divider = $Line['text'];
+
+        $divider = trim($divider);
+        $divider = trim($divider, '|');
+
+        $dividerCells = explode('|', $divider);
+
+        foreach ($dividerCells as $dividerCell)
+        {
+            $dividerCell = trim($dividerCell);
+
+            if ($dividerCell === '')
+            {
+                return;
+            }
+
+            $alignment = null;
+
+            if ($dividerCell[0] === ':')
+            {
+                $alignment = 'left';
+            }
+
+            if (substr($dividerCell, - 1) === ':')
+            {
+                $alignment = $alignment === 'left' ? 'center' : 'right';
+            }
+
+            $alignments []= $alignment;
+        }
+
+        # ~
+
+        $HeaderElements = array();
+
+        $header = $Block['element']['handler']['argument'];
+
+        $header = trim($header);
+        $header = trim($header, '|');
+
+        $headerCells = explode('|', $header);
+
+        if (count($headerCells) !== count($alignments))
+        {
+            return;
+        }
+
+        foreach ($headerCells as $index => $headerCell)
+        {
+            $headerCell = trim($headerCell);
+
+            $HeaderElement = array(
+                'name' => 'th',
+                'handler' => array(
+                    'function' => 'lineElements',
+                    'argument' => $headerCell,
+                    'destination' => 'elements',
+                )
+            );
+
+            if (isset($alignments[$index]))
+            {
+                $alignment = $alignments[$index];
+
+                $HeaderElement['attributes'] = array(
+                    'style' => "text-align: $alignment;",
+                );
+            }
+
+            $HeaderElements []= $HeaderElement;
+        }
+
+        # ~
+
+        $Block = array(
+            'alignments' => $alignments,
+            'identified' => true,
+            'element' => array(
+                'name' => 'table',
+                'elements' => array(),
+            ),
+        );
+
+        $Block['element']['elements'] []= array(
+            'name' => 'thead',
+        );
+
+        $Block['element']['elements'] []= array(
+            'name' => 'tbody',
+            'elements' => array(),
+        );
+
+        $Block['element']['elements'][0]['elements'] []= array(
+            'name' => 'tr',
+            'elements' => $HeaderElements,
+        );
+
+        return $Block;
+    }
+
+    protected function blockTableContinue($Line, array $Block)
+    {
+        if (isset($Block['interrupted']))
+        {
+            return;
+        }
+
+        if (count($Block['alignments']) === 1 or $Line['text'][0] === '|' or strpos($Line['text'], '|'))
+        {
+            $Elements = array();
+
+            $row = $Line['text'];
+
+            $row = trim($row);
+            $row = trim($row, '|');
+
+            preg_match_all('/(?:(\\\\[|])|[^|`]|`[^`]++`|`)++/', $row, $matches);
+
+            $cells = array_slice($matches[0], 0, count($Block['alignments']));
+
+            foreach ($cells as $index => $cell)
+            {
+                $cell = trim($cell);
+
+                $Element = array(
+                    'name' => 'td',
+                    'handler' => array(
+                        'function' => 'lineElements',
+                        'argument' => $cell,
+                        'destination' => 'elements',
+                    )
+                );
+
+                if (isset($Block['alignments'][$index]))
+                {
+                    $Element['attributes'] = array(
+                        'style' => 'text-align: ' . $Block['alignments'][$index] . ';',
+                    );
+                }
+
+                $Elements []= $Element;
+            }
+
+            $Element = array(
+                'name' => 'tr',
+                'elements' => $Elements,
+            );
+
+            $Block['element']['elements'][1]['elements'] []= $Element;
+
+            return $Block;
+        }
+    }
+
+    #
+    # ~
+    #
+
+    protected function paragraph($Line)
+    {
+        return array(
+            'type' => 'Paragraph',
+            'element' => array(
+                'name' => 'p',
+                'handler' => array(
+                    'function' => 'lineElements',
+                    'argument' => $Line['text'],
+                    'destination' => 'elements',
+                ),
+            ),
+        );
+    }
+
+    protected function paragraphContinue($Line, array $Block)
+    {
+        if (isset($Block['interrupted']))
+        {
+            return;
+        }
+
+        $Block['element']['handler']['argument'] .= "\n".$Line['text'];
+
+        return $Block;
+    }
+
+    #
+    # Inline Elements
+    #
+
+    protected $InlineTypes = array(
+        '!' => array('Image'),
+        '&' => array('SpecialCharacter'),
+        '*' => array('Emphasis'),
+        ':' => array('Url'),
+        '<' => array('UrlTag', 'EmailTag', 'Markup'),
+        '[' => array('Link'),
+        '_' => array('Emphasis'),
+        '`' => array('Code'),
+        '~' => array('Strikethrough'),
+        '\\' => array('EscapeSequence'),
+    );
+
+    # ~
+
+    protected $inlineMarkerList = '!*_&[:<`~\\';
+
+    #
+    # ~
+    #
+
+    public function line($text, $nonNestables = array())
+    {
+        return $this->elements($this->lineElements($text, $nonNestables));
+    }
+
+    protected function lineElements($text, $nonNestables = array())
+    {
+        # standardize line breaks
+        $text = str_replace(array("\r\n", "\r"), "\n", $text);
+
+        $Elements = array();
+
+        $nonNestables = (empty($nonNestables)
+            ? array()
+            : array_combine($nonNestables, $nonNestables)
+        );
+
+        # $excerpt is based on the first occurrence of a marker
+
+        while ($excerpt = strpbrk($text, $this->inlineMarkerList))
+        {
+            $marker = $excerpt[0];
+
+            $markerPosition = strlen($text) - strlen($excerpt);
+
+            $Excerpt = array('text' => $excerpt, 'context' => $text);
+
+            foreach ($this->InlineTypes[$marker] as $inlineType)
+            {
+                # check to see if the current inline type is nestable in the current context
+
+                if (isset($nonNestables[$inlineType]))
+                {
+                    continue;
+                }
+
+                $Inline = $this->{"inline$inlineType"}($Excerpt);
+
+                if ( ! isset($Inline))
+                {
+                    continue;
+                }
+
+                # makes sure that the inline belongs to "our" marker
+
+                if (isset($Inline['position']) and $Inline['position'] > $markerPosition)
+                {
+                    continue;
+                }
+
+                # sets a default inline position
+
+                if ( ! isset($Inline['position']))
+                {
+                    $Inline['position'] = $markerPosition;
+                }
+
+                # cause the new element to 'inherit' our non nestables
+
+
+                $Inline['element']['nonNestables'] = isset($Inline['element']['nonNestables'])
+                    ? array_merge($Inline['element']['nonNestables'], $nonNestables)
+                    : $nonNestables
+                ;
+
+                # the text that comes before the inline
+                $unmarkedText = substr($text, 0, $Inline['position']);
+
+                # compile the unmarked text
+                $InlineText = $this->inlineText($unmarkedText);
+                $Elements[] = $InlineText['element'];
+
+                # compile the inline
+                $Elements[] = $this->extractElement($Inline);
+
+                # remove the examined text
+                $text = substr($text, $Inline['position'] + $Inline['extent']);
+
+                continue 2;
+            }
+
+            # the marker does not belong to an inline
+
+            $unmarkedText = substr($text, 0, $markerPosition + 1);
+
+            $InlineText = $this->inlineText($unmarkedText);
+            $Elements[] = $InlineText['element'];
+
+            $text = substr($text, $markerPosition + 1);
+        }
+
+        $InlineText = $this->inlineText($text);
+        $Elements[] = $InlineText['element'];
+
+        foreach ($Elements as &$Element)
+        {
+            if ( ! isset($Element['autobreak']))
+            {
+                $Element['autobreak'] = false;
+            }
+        }
+
+        return $Elements;
+    }
+
+    #
+    # ~
+    #
+
+    protected function inlineText($text)
+    {
+        $Inline = array(
+            'extent' => strlen($text),
+            'element' => array(),
+        );
+
+        $Inline['element']['elements'] = self::pregReplaceElements(
+            $this->breaksEnabled ? '/[ ]*+\n/' : '/(?:[ ]*+\\\\|[ ]{2,}+)\n/',
+            array(
+                array('name' => 'br'),
+                array('text' => "\n"),
+            ),
+            $text
+        );
+
+        return $Inline;
+    }
+
+    protected function inlineCode($Excerpt)
+    {
+        $marker = $Excerpt['text'][0];
+
+        if (preg_match('/^(['.$marker.']++)[ ]*+(.+?)[ ]*+(?<!['.$marker.'])\1(?!'.$marker.')/s', $Excerpt['text'], $matches))
+        {
+            $text = $matches[2];
+            $text = preg_replace('/[ ]*+\n/', ' ', $text);
+
+            return array(
+                'extent' => strlen($matches[0]),
+                'element' => array(
+                    'name' => 'code',
+                    'text' => $text,
+                ),
+            );
+        }
+    }
+
+    protected function inlineEmailTag($Excerpt)
+    {
+        $hostnameLabel = '[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?';
+
+        $commonMarkEmail = '[a-zA-Z0-9.!#$%&\'*+\/=?^_`{|}~-]++@'
+            . $hostnameLabel . '(?:\.' . $hostnameLabel . ')*';
+
+        if (strpos($Excerpt['text'], '>') !== false
+            and preg_match("/^<((mailto:)?$commonMarkEmail)>/i", $Excerpt['text'], $matches)
+        ){
+            $url = $matches[1];
+
+            if ( ! isset($matches[2]))
+            {
+                $url = "mailto:$url";
+            }
+
+            return array(
+                'extent' => strlen($matches[0]),
+                'element' => array(
+                    'name' => 'a',
+                    'text' => $matches[1],
+                    'attributes' => array(
+                        'href' => $url,
+                    ),
+                ),
+            );
+        }
+    }
+
+    protected function inlineEmphasis($Excerpt)
+    {
+        if ( ! isset($Excerpt['text'][1]))
+        {
+            return;
+        }
+
+        $marker = $Excerpt['text'][0];
+
+        if ($Excerpt['text'][1] === $marker and preg_match($this->StrongRegex[$marker], $Excerpt['text'], $matches))
+        {
+            $emphasis = 'strong';
+        }
+        elseif (preg_match($this->EmRegex[$marker], $Excerpt['text'], $matches))
+        {
+            $emphasis = 'em';
+        }
+        else
+        {
+            return;
+        }
+
+        return array(
+            'extent' => strlen($matches[0]),
+            'element' => array(
+                'name' => $emphasis,
+                'handler' => array(
+                    'function' => 'lineElements',
+                    'argument' => $matches[1],
+                    'destination' => 'elements',
+                )
+            ),
+        );
+    }
+
+    protected function inlineEscapeSequence($Excerpt)
+    {
+        if (isset($Excerpt['text'][1]) and in_array($Excerpt['text'][1], $this->specialCharacters))
+        {
+            return array(
+                'element' => array('rawHtml' => $Excerpt['text'][1]),
+                'extent' => 2,
+            );
+        }
+    }
+
+    protected function inlineImage($Excerpt)
+    {
+        if ( ! isset($Excerpt['text'][1]) or $Excerpt['text'][1] !== '[')
+        {
+            return;
+        }
+
+        $Excerpt['text']= substr($Excerpt['text'], 1);
+
+        $Link = $this->inlineLink($Excerpt);
+
+        if ($Link === null)
+        {
+            return;
+        }
+
+        $Inline = array(
+            'extent' => $Link['extent'] + 1,
+            'element' => array(
+                'name' => 'img',
+                'attributes' => array(
+                    'src' => $Link['element']['attributes']['href'],
+                    'alt' => $Link['element']['handler']['argument'],
+                ),
+                'autobreak' => true,
+            ),
+        );
+
+        $Inline['element']['attributes'] += $Link['element']['attributes'];
+
+        unset($Inline['element']['attributes']['href']);
+
+        return $Inline;
+    }
+
+    protected function inlineLink($Excerpt)
+    {
+        $Element = array(
+            'name' => 'a',
+            'handler' => array(
+                'function' => 'lineElements',
+                'argument' => null,
+                'destination' => 'elements',
+            ),
+            'nonNestables' => array('Url', 'Link'),
+            'attributes' => array(
+                'href' => null,
+                'title' => null,
+            ),
+        );
+
+        $extent = 0;
+
+        $remainder = $Excerpt['text'];
+
+        if (preg_match('/\[((?:[^][]++|(?R))*+)\]/', $remainder, $matches))
+        {
+            $Element['handler']['argument'] = $matches[1];
+
+            $extent += strlen($matches[0]);
+
+            $remainder = substr($remainder, $extent);
+        }
+        else
+        {
+            return;
+        }
+
+        if (preg_match('/^[(]\s*+((?:[^ ()]++|[(][^ )]+[)])++)(?:[ ]+("[^"]*+"|\'[^\']*+\'))?\s*+[)]/', $remainder, $matches))
+        {
+            $Element['attributes']['href'] = $matches[1];
+
+            if (isset($matches[2]))
+            {
+                $Element['attributes']['title'] = substr($matches[2], 1, - 1);
+            }
+
+            $extent += strlen($matches[0]);
+        }
+        else
+        {
+            if (preg_match('/^\s*\[(.*?)\]/', $remainder, $matches))
+            {
+                $definition = strlen($matches[1]) ? $matches[1] : $Element['handler']['argument'];
+                $definition = strtolower($definition);
+
+                $extent += strlen($matches[0]);
+            }
+            else
+            {
+                $definition = strtolower($Element['handler']['argument']);
+            }
+
+            if ( ! isset($this->DefinitionData['Reference'][$definition]))
+            {
+                return;
+            }
+
+            $Definition = $this->DefinitionData['Reference'][$definition];
+
+            $Element['attributes']['href'] = $Definition['url'];
+            $Element['attributes']['title'] = $Definition['title'];
+        }
+
+        return array(
+            'extent' => $extent,
+            'element' => $Element,
+        );
+    }
+
+    protected function inlineMarkup($Excerpt)
+    {
+        if ($this->markupEscaped or $this->safeMode or strpos($Excerpt['text'], '>') === false)
+        {
+            return;
+        }
+
+        if ($Excerpt['text'][1] === '/' and preg_match('/^<\/\w[\w-]*+[ ]*+>/s', $Excerpt['text'], $matches))
+        {
+            return array(
+                'element' => array('rawHtml' => $matches[0]),
+                'extent' => strlen($matches[0]),
+            );
+        }
+
+        if ($Excerpt['text'][1] === '!' and preg_match('/^<!---?[^>-](?:-?+[^-])*-->/s', $Excerpt['text'], $matches))
+        {
+            return array(
+                'element' => array('rawHtml' => $matches[0]),
+                'extent' => strlen($matches[0]),
+            );
+        }
+
+        if ($Excerpt['text'][1] !== ' ' and preg_match('/^<\w[\w-]*+(?:[ ]*+'.$this->regexHtmlAttribute.')*+[ ]*+\/?>/s', $Excerpt['text'], $matches))
+        {
+            return array(
+                'element' => array('rawHtml' => $matches[0]),
+                'extent' => strlen($matches[0]),
+            );
+        }
+    }
+
+    protected function inlineSpecialCharacter($Excerpt)
+    {
+        if (substr($Excerpt['text'], 1, 1) !== ' ' and strpos($Excerpt['text'], ';') !== false
+            and preg_match('/^&(#?+[0-9a-zA-Z]++);/', $Excerpt['text'], $matches)
+        ) {
+            return array(
+                'element' => array('rawHtml' => '&' . $matches[1] . ';'),
+                'extent' => strlen($matches[0]),
+            );
+        }
+    }
+
+    protected function inlineStrikethrough($Excerpt)
+    {
+        if ( ! isset($Excerpt['text'][1]))
+        {
+            return;
+        }
+
+        if ($Excerpt['text'][1] === '~' and preg_match('/^~~(?=\S)(.+?)(?<=\S)~~/', $Excerpt['text'], $matches))
+        {
+            return array(
+                'extent' => strlen($matches[0]),
+                'element' => array(
+                    'name' => 'del',
+                    'handler' => array(
+                        'function' => 'lineElements',
+                        'argument' => $matches[1],
+                        'destination' => 'elements',
+                    )
+                ),
+            );
+        }
+    }
+
+    protected function inlineUrl($Excerpt)
+    {
+        if ($this->urlsLinked !== true or ! isset($Excerpt['text'][2]) or $Excerpt['text'][2] !== '/')
+        {
+            return;
+        }
+
+        if (strpos($Excerpt['context'], 'http') !== false
+            and preg_match('/\bhttps?+:[\/]{2}[^\s<]+\b\/*+/ui', $Excerpt['context'], $matches, PREG_OFFSET_CAPTURE)
+        ) {
+            $url = $matches[0][0];
+
+            $Inline = array(
+                'extent' => strlen($matches[0][0]),
+                'position' => $matches[0][1],
+                'element' => array(
+                    'name' => 'a',
+                    'text' => $url,
+                    'attributes' => array(
+                        'href' => $url,
+                    ),
+                ),
+            );
+
+            return $Inline;
+        }
+    }
+
+    protected function inlineUrlTag($Excerpt)
+    {
+        if (strpos($Excerpt['text'], '>') !== false and preg_match('/^<(\w++:\/{2}[^ >]++)>/i', $Excerpt['text'], $matches))
+        {
+            $url = $matches[1];
+
+            return array(
+                'extent' => strlen($matches[0]),
+                'element' => array(
+                    'name' => 'a',
+                    'text' => $url,
+                    'attributes' => array(
+                        'href' => $url,
+                    ),
+                ),
+            );
+        }
+    }
+
+    # ~
+
+    protected function unmarkedText($text)
+    {
+        $Inline = $this->inlineText($text);
+        return $this->element($Inline['element']);
+    }
+
+    #
+    # Handlers
+    #
+
+    protected function handle(array $Element)
+    {
+        if (isset($Element['handler']))
+        {
+            if (!isset($Element['nonNestables']))
+            {
+                $Element['nonNestables'] = array();
+            }
+
+            if (is_string($Element['handler']))
+            {
+                $function = $Element['handler'];
+                $argument = $Element['text'];
+                unset($Element['text']);
+                $destination = 'rawHtml';
+            }
+            else
+            {
+                $function = $Element['handler']['function'];
+                $argument = $Element['handler']['argument'];
+                $destination = $Element['handler']['destination'];
+            }
+
+            $Element[$destination] = $this->{$function}($argument, $Element['nonNestables']);
+
+            if ($destination === 'handler')
+            {
+                $Element = $this->handle($Element);
+            }
+
+            unset($Element['handler']);
+        }
+
+        return $Element;
+    }
+
+    protected function handleElementRecursive(array $Element)
+    {
+        return $this->elementApplyRecursive(array($this, 'handle'), $Element);
+    }
+
+    protected function handleElementsRecursive(array $Elements)
+    {
+        return $this->elementsApplyRecursive(array($this, 'handle'), $Elements);
+    }
+
+    protected function elementApplyRecursive($closure, array $Element)
+    {
+        $Element = call_user_func($closure, $Element);
+
+        if (isset($Element['elements']))
+        {
+            $Element['elements'] = $this->elementsApplyRecursive($closure, $Element['elements']);
+        }
+        elseif (isset($Element['element']))
+        {
+            $Element['element'] = $this->elementApplyRecursive($closure, $Element['element']);
+        }
+
+        return $Element;
+    }
+
+    protected function elementApplyRecursiveDepthFirst($closure, array $Element)
+    {
+        if (isset($Element['elements']))
+        {
+            $Element['elements'] = $this->elementsApplyRecursiveDepthFirst($closure, $Element['elements']);
+        }
+        elseif (isset($Element['element']))
+        {
+            $Element['element'] = $this->elementsApplyRecursiveDepthFirst($closure, $Element['element']);
+        }
+
+        $Element = call_user_func($closure, $Element);
+
+        return $Element;
+    }
+
+    protected function elementsApplyRecursive($closure, array $Elements)
+    {
+        foreach ($Elements as &$Element)
+        {
+            $Element = $this->elementApplyRecursive($closure, $Element);
+        }
+
+        return $Elements;
+    }
+
+    protected function elementsApplyRecursiveDepthFirst($closure, array $Elements)
+    {
+        foreach ($Elements as &$Element)
+        {
+            $Element = $this->elementApplyRecursiveDepthFirst($closure, $Element);
+        }
+
+        return $Elements;
+    }
+
+    protected function element(array $Element)
+    {
+        if ($this->safeMode)
+        {
+            $Element = $this->sanitiseElement($Element);
+        }
+
+        # identity map if element has no handler
+        $Element = $this->handle($Element);
+
+        $hasName = isset($Element['name']);
+
+        $markup = '';
+
+        if ($hasName)
+        {
+            $markup .= '<' . $Element['name'];
+
+            if (isset($Element['attributes']))
+            {
+                foreach ($Element['attributes'] as $name => $value)
+                {
+                    if ($value === null)
+                    {
+                        continue;
+                    }
+
+                    $markup .= " $name=\"".self::escape($value).'"';
+                }
+            }
+        }
+
+        $permitRawHtml = false;
+
+        if (isset($Element['text']))
+        {
+            $text = $Element['text'];
+        }
+        // very strongly consider an alternative if you're writing an
+        // extension
+        elseif (isset($Element['rawHtml']))
+        {
+            $text = $Element['rawHtml'];
+
+            $allowRawHtmlInSafeMode = isset($Element['allowRawHtmlInSafeMode']) && $Element['allowRawHtmlInSafeMode'];
+            $permitRawHtml = !$this->safeMode || $allowRawHtmlInSafeMode;
+        }
+
+        $hasContent = isset($text) || isset($Element['element']) || isset($Element['elements']);
+
+        if ($hasContent)
+        {
+            $markup .= $hasName ? '>' : '';
+
+            if (isset($Element['elements']))
+            {
+                $markup .= $this->elements($Element['elements']);
+            }
+            elseif (isset($Element['element']))
+            {
+                $markup .= $this->element($Element['element']);
+            }
+            else
+            {
+                if (!$permitRawHtml)
+                {
+                    $markup .= self::escape($text, true);
+                }
+                else
+                {
+                    $markup .= $text;
+                }
+            }
+
+            $markup .= $hasName ? '</' . $Element['name'] . '>' : '';
+        }
+        elseif ($hasName)
+        {
+            $markup .= ' />';
+        }
+
+        return $markup;
+    }
+
+    protected function elements(array $Elements)
+    {
+        $markup = '';
+
+        $autoBreak = true;
+
+        foreach ($Elements as $Element)
+        {
+            if (empty($Element))
+            {
+                continue;
+            }
+
+            $autoBreakNext = (isset($Element['autobreak'])
+                ? $Element['autobreak'] : isset($Element['name'])
+            );
+            // (autobreak === false) covers both sides of an element
+            $autoBreak = !$autoBreak ? $autoBreak : $autoBreakNext;
+
+            $markup .= ($autoBreak ? "\n" : '') . $this->element($Element);
+            $autoBreak = $autoBreakNext;
+        }
+
+        $markup .= $autoBreak ? "\n" : '';
+
+        return $markup;
+    }
+
+    # ~
+
+    protected function li($lines)
+    {
+        $Elements = $this->linesElements($lines);
+
+        if ( ! in_array('', $lines)
+            and isset($Elements[0]) and isset($Elements[0]['name'])
+            and $Elements[0]['name'] === 'p'
+        ) {
+            unset($Elements[0]['name']);
+        }
+
+        return $Elements;
+    }
+
+    #
+    # AST Convenience
+    #
+
+    /**
+     * Replace occurrences $regexp with $Elements in $text. Return an array of
+     * elements representing the replacement.
+     */
+    protected static function pregReplaceElements($regexp, $Elements, $text)
+    {
+        $newElements = array();
+
+        while (preg_match($regexp, $text, $matches, PREG_OFFSET_CAPTURE))
+        {
+            $offset = $matches[0][1];
+            $before = substr($text, 0, $offset);
+            $after = substr($text, $offset + strlen($matches[0][0]));
+
+            $newElements[] = array('text' => $before);
+
+            foreach ($Elements as $Element)
+            {
+                $newElements[] = $Element;
+            }
+
+            $text = $after;
+        }
+
+        $newElements[] = array('text' => $text);
+
+        return $newElements;
+    }
+
+    #
+    # Deprecated Methods
+    #
+
+    /**
+     * @deprecated use text() instead
+     */
+    function parse($text)
+    {
+        $markup = $this->text($text);
+
+        return $markup;
+    }
+
+    protected function sanitiseElement(array $Element)
+    {
+        static $goodAttribute = '/^[a-zA-Z0-9][a-zA-Z0-9-_]*+$/';
+        static $safeUrlNameToAtt  = array(
+            'a'   => 'href',
+            'img' => 'src',
+        );
+
+        if ( ! isset($Element['name']))
+        {
+            unset($Element['attributes']);
+            return $Element;
+        }
+
+        if (isset($safeUrlNameToAtt[$Element['name']]))
+        {
+            $Element = $this->filterUnsafeUrlInAttribute($Element, $safeUrlNameToAtt[$Element['name']]);
+        }
+
+        if ( ! empty($Element['attributes']))
+        {
+            foreach ($Element['attributes'] as $att => $val)
+            {
+                # filter out badly parsed attribute
+                if ( ! preg_match($goodAttribute, $att))
+                {
+                    unset($Element['attributes'][$att]);
+                }
+                # dump onevent attribute
+                elseif (self::striAtStart($att, 'on'))
+                {
+                    unset($Element['attributes'][$att]);
+                }
+            }
+        }
+
+        return $Element;
+    }
+
+    protected function filterUnsafeUrlInAttribute(array $Element, $attribute)
+    {
+        foreach ($this->safeLinksWhitelist as $scheme)
+        {
+            if (self::striAtStart($Element['attributes'][$attribute], $scheme))
+            {
+                return $Element;
+            }
+        }
+
+        $Element['attributes'][$attribute] = str_replace(':', '%3A', $Element['attributes'][$attribute]);
+
+        return $Element;
+    }
+
+    #
+    # Static Methods
+    #
+
+    protected static function escape($text, $allowQuotes = false)
+    {
+        return htmlspecialchars($text, $allowQuotes ? ENT_NOQUOTES : ENT_QUOTES, 'UTF-8');
+    }
+
+    protected static function striAtStart($string, $needle)
+    {
+        $len = strlen($needle);
+
+        if ($len > strlen($string))
+        {
+            return false;
+        }
+        else
+        {
+            return strtolower(substr($string, 0, $len)) === strtolower($needle);
+        }
+    }
+
+    static function instance($name = 'default')
+    {
+        if (isset(self::$instances[$name]))
+        {
+            return self::$instances[$name];
+        }
+
+        $instance = new static();
+
+        self::$instances[$name] = $instance;
+
+        return $instance;
+    }
+
+    private static $instances = array();
+
+    #
+    # Fields
+    #
+
+    protected $DefinitionData;
+
+    #
+    # Read-Only
+
+    protected $specialCharacters = array(
+        '\\', '`', '*', '_', '{', '}', '[', ']', '(', ')', '>', '#', '+', '-', '.', '!', '|', '~'
+    );
+
+    protected $StrongRegex = array(
+        '*' => '/^[*]{2}((?:\\\\\*|[^*]|[*][^*]*+[*])+?)[*]{2}(?![*])/s',
+        '_' => '/^__((?:\\\\_|[^_]|_[^_]*+_)+?)__(?!_)/us',
+    );
+
+    protected $EmRegex = array(
+        '*' => '/^[*]((?:\\\\\*|[^*]|[*][*][^*]+?[*][*])+?)[*](?![*])/s',
+        '_' => '/^_((?:\\\\_|[^_]|__[^_]*__)+?)_(?!_)\b/us',
+    );
+
+    protected $regexHtmlAttribute = '[a-zA-Z_:][\w:.-]*+(?:\s*+=\s*+(?:[^"\'=<>`\s]+|"[^"]*+"|\'[^\']*+\'))?+';
+
+    protected $voidElements = array(
+        'area', 'base', 'br', 'col', 'command', 'embed', 'hr', 'img', 'input', 'link', 'meta', 'param', 'source',
+    );
+
+    protected $textLevelElements = array(
+        'a', 'br', 'bdo', 'abbr', 'blink', 'nextid', 'acronym', 'basefont',
+        'b', 'em', 'big', 'cite', 'small', 'spacer', 'listing',
+        'i', 'rp', 'del', 'code',          'strike', 'marquee',
+        'q', 'rt', 'ins', 'font',          'strong',
+        's', 'tt', 'kbd', 'mark',
+        'u', 'xm', 'sub', 'nobr',
+                   'sup', 'ruby',
+                   'var', 'span',
+                   'wbr', 'time',
+    );
+}

--- a/public/input.css
+++ b/public/input.css
@@ -9,6 +9,10 @@ emoji-picker {
   --num-columns: 6;
 }
 
+ul {
+    list-style: disc;
+}
+
 .range-start {
     @apply bg-sky-500 text-white rounded-l-xl;
 }

--- a/public/output.css
+++ b/public/output.css
@@ -308,8 +308,17 @@
   .inset-0 {
     inset: calc(var(--spacing) * 0);
   }
+  .inset-7 {
+    inset: calc(var(--spacing) * 7);
+  }
+  .inset-x-\[-10\] {
+    inset-inline: -10;
+  }
   .inset-y-0 {
     inset-block: calc(var(--spacing) * 0);
+  }
+  .inset-y-10 {
+    inset-block: calc(var(--spacing) * 10);
   }
   .start-0 {
     inset-inline-start: calc(var(--spacing) * 0);
@@ -319,6 +328,9 @@
   }
   .top-0 {
     top: calc(var(--spacing) * 0);
+  }
+  .top-5 {
+    top: calc(var(--spacing) * 5);
   }
   .top-10 {
     top: calc(var(--spacing) * 10);
@@ -332,11 +344,17 @@
   .right-4 {
     right: calc(var(--spacing) * 4);
   }
+  .right-5 {
+    right: calc(var(--spacing) * 5);
+  }
   .bottom-0 {
     bottom: calc(var(--spacing) * 0);
   }
   .left-0 {
     left: calc(var(--spacing) * 0);
+  }
+  .left-1 {
+    left: calc(var(--spacing) * 1);
   }
   .left-10 {
     left: calc(var(--spacing) * 10);
@@ -578,6 +596,10 @@
   .field-sizing-fixed {
     field-sizing: fixed;
   }
+  .size-4 {
+    width: calc(var(--spacing) * 4);
+    height: calc(var(--spacing) * 4);
+  }
   .size-6 {
     width: calc(var(--spacing) * 6);
     height: calc(var(--spacing) * 6);
@@ -589,6 +611,10 @@
   .size-8 {
     width: calc(var(--spacing) * 8);
     height: calc(var(--spacing) * 8);
+  }
+  .size-10 {
+    width: calc(var(--spacing) * 10);
+    height: calc(var(--spacing) * 10);
   }
   .size-auto {
     width: auto;
@@ -649,9 +675,6 @@
   .w-1\/2 {
     width: calc(1/2 * 100%);
   }
-  .w-1\/3 {
-    width: calc(1/3 * 100%);
-  }
   .w-1\/4 {
     width: calc(1/4 * 100%);
   }
@@ -670,11 +693,14 @@
   .w-3\/4 {
     width: calc(3/4 * 100%);
   }
+  .w-3\/10 {
+    width: calc(3/10 * 100%);
+  }
   .w-4 {
     width: calc(var(--spacing) * 4);
   }
-  .w-7\/8 {
-    width: calc(7/8 * 100%);
+  .w-7\/10 {
+    width: calc(7/10 * 100%);
   }
   .w-15 {
     width: calc(var(--spacing) * 15);
@@ -1423,9 +1449,6 @@
   .bg-\[var\(--my_variable\)\] {
     background-color: var(--my_variable);
   }
-  .bg-blue-400 {
-    background-color: var(--color-blue-400);
-  }
   .bg-blue-700 {
     background-color: var(--color-blue-700);
   }
@@ -1881,9 +1904,6 @@
   .py-4 {
     padding-block: calc(var(--spacing) * 4);
   }
-  .py-6 {
-    padding-block: calc(var(--spacing) * 6);
-  }
   .py-20 {
     padding-block: calc(var(--spacing) * 20);
   }
@@ -1905,11 +1925,11 @@
   .pr-10 {
     padding-right: calc(var(--spacing) * 10);
   }
-  .pb-3 {
-    padding-bottom: calc(var(--spacing) * 3);
-  }
   .pb-6 {
     padding-bottom: calc(var(--spacing) * 6);
+  }
+  .pl-10 {
+    padding-left: calc(var(--spacing) * 10);
   }
   .text-center {
     text-align: center;
@@ -2082,9 +2102,6 @@
   }
   .\[color\:red\]\/50\! {
     color: color-mix(in oklab, red 50%, transparent) !important;
-  }
-  .text-blue-400 {
-    color: var(--color-blue-400);
   }
   .text-blue-500 {
     color: var(--color-blue-500);
@@ -2558,13 +2575,6 @@
       }
     }
   }
-  .hover\:bg-red-400 {
-    &:hover {
-      @media (hover: hover) {
-        background-color: var(--color-red-400);
-      }
-    }
-  }
   .hover\:bg-sky-100 {
     &:hover {
       @media (hover: hover) {
@@ -2590,13 +2600,6 @@
     &:hover {
       @media (hover: hover) {
         color: var(--color-gray-200);
-      }
-    }
-  }
-  .hover\:text-gray-500 {
-    &:hover {
-      @media (hover: hover) {
-        color: var(--color-gray-500);
       }
     }
   }
@@ -2729,11 +2732,6 @@
       background-color: var(--color-gray-300);
     }
   }
-  .disabled\:bg-gray-400 {
-    &:disabled {
-      background-color: var(--color-gray-400);
-    }
-  }
   .disabled\:outline-gray-500 {
     &:disabled {
       outline-color: var(--color-gray-500);
@@ -2757,6 +2755,24 @@
   .data-closed\:-translate-x-full {
     &[data-closed] {
       --tw-translate-x: -100%;
+      translate: var(--tw-translate-x) var(--tw-translate-y);
+    }
+  }
+  .data-closed\:translate-x-3\/20 {
+    &[data-closed] {
+      --tw-translate-x: calc(3/20 * 100%);
+      translate: var(--tw-translate-x) var(--tw-translate-y);
+    }
+  }
+  .data-closed\:translate-x-7\/20 {
+    &[data-closed] {
+      --tw-translate-x: calc(7/20 * 100%);
+      translate: var(--tw-translate-x) var(--tw-translate-y);
+    }
+  }
+  .data-closed\:translate-x-full {
+    &[data-closed] {
+      --tw-translate-x: 100%;
       translate: var(--tw-translate-x) var(--tw-translate-y);
     }
   }
@@ -2933,6 +2949,9 @@
 }
 emoji-picker {
   --num-columns: 6;
+}
+ul {
+  list-style: disc;
 }
 .range-start {
   border-top-left-radius: var(--radius-xl);

--- a/public/output.css
+++ b/public/output.css
@@ -308,17 +308,8 @@
   .inset-0 {
     inset: calc(var(--spacing) * 0);
   }
-  .inset-7 {
-    inset: calc(var(--spacing) * 7);
-  }
-  .inset-x-\[-10\] {
-    inset-inline: -10;
-  }
   .inset-y-0 {
     inset-block: calc(var(--spacing) * 0);
-  }
-  .inset-y-10 {
-    inset-block: calc(var(--spacing) * 10);
   }
   .start-0 {
     inset-inline-start: calc(var(--spacing) * 0);
@@ -352,9 +343,6 @@
   }
   .left-0 {
     left: calc(var(--spacing) * 0);
-  }
-  .left-1 {
-    left: calc(var(--spacing) * 1);
   }
   .left-10 {
     left: calc(var(--spacing) * 10);
@@ -596,10 +584,6 @@
   .field-sizing-fixed {
     field-sizing: fixed;
   }
-  .size-4 {
-    width: calc(var(--spacing) * 4);
-    height: calc(var(--spacing) * 4);
-  }
   .size-6 {
     width: calc(var(--spacing) * 6);
     height: calc(var(--spacing) * 6);
@@ -611,10 +595,6 @@
   .size-8 {
     width: calc(var(--spacing) * 8);
     height: calc(var(--spacing) * 8);
-  }
-  .size-10 {
-    width: calc(var(--spacing) * 10);
-    height: calc(var(--spacing) * 10);
   }
   .size-auto {
     width: auto;
@@ -635,6 +615,9 @@
   }
   .h-39 {
     height: calc(var(--spacing) * 39);
+  }
+  .h-40 {
+    height: calc(var(--spacing) * 40);
   }
   .h-\[20vh\] {
     height: 20vh;
@@ -1449,6 +1432,9 @@
   .bg-\[var\(--my_variable\)\] {
     background-color: var(--my_variable);
   }
+  .bg-blue-500 {
+    background-color: var(--color-blue-500);
+  }
   .bg-blue-700 {
     background-color: var(--color-blue-700);
   }
@@ -1460,6 +1446,12 @@
   }
   .bg-gray-300 {
     background-color: var(--color-gray-300);
+  }
+  .bg-gray-400 {
+    background-color: var(--color-gray-400);
+  }
+  .bg-gray-500 {
+    background-color: var(--color-gray-500);
   }
   .bg-gray-900\/50 {
     background-color: color-mix(in srgb, oklch(21% 0.034 264.665) 50%, transparent);
@@ -1928,8 +1920,8 @@
   .pb-6 {
     padding-bottom: calc(var(--spacing) * 6);
   }
-  .pl-10 {
-    padding-left: calc(var(--spacing) * 10);
+  .pl-3 {
+    padding-left: calc(var(--spacing) * 3);
   }
   .text-center {
     text-align: center;
@@ -2755,18 +2747,6 @@
   .data-closed\:-translate-x-full {
     &[data-closed] {
       --tw-translate-x: -100%;
-      translate: var(--tw-translate-x) var(--tw-translate-y);
-    }
-  }
-  .data-closed\:translate-x-3\/20 {
-    &[data-closed] {
-      --tw-translate-x: calc(3/20 * 100%);
-      translate: var(--tw-translate-x) var(--tw-translate-y);
-    }
-  }
-  .data-closed\:translate-x-7\/20 {
-    &[data-closed] {
-      --tw-translate-x: calc(7/20 * 100%);
       translate: var(--tw-translate-x) var(--tw-translate-y);
     }
   }

--- a/vercel.json
+++ b/vercel.json
@@ -16,6 +16,10 @@
   ],
   "rewrites": [
     {
+      "source": "/docs/:match",
+      "destination": "/api/document.php"
+    },
+    {
       "source": "/:match",
       "destination": "/api/:match"
     },


### PR DESCRIPTION
This branch enables the links for documents to actually be used an view the stored documents from Neon PostgreSQL. It also includes the addition of comments, which cannot be created/changed by users yet but do have a table in Neon that the doc viewing page pulls from.

## Current Issues / To Dos:
- Currently when the comment drawer is opened, the document becomes unscrollable (this is because Tailwind adds a backdrop that stops interactability with other parts of the page, even if it's translucent and/or not directly called for in the HTML. Just look in the DOM when you have the page open, it appears as "::backdrop"). Either a way to disable this function is necessary, OR just abandoning the Tailwind method and manually animating could work, like I did with the document anyway.

- Also, the button to open comments is currently a placeholder.

- There is no button or link to return to the previous page, this should be added in design and then to the code.

- Also no implementation to download opened document.

@adameriogvsu I'm not going to pull this PR myself, as I figured future work may want to be done on this branch depending on goals this summer, and you would probably want to do your own testing to determine if these changes should be done here or on a future branch.